### PR TITLE
Create `PilotTestSupport`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,10 @@ let package = Package(
             targets: ["Pilot"]
         ),
         .library(
+            name: "PilotTestSupport",
+            targets: ["PilotTestSupport"]
+        ),
+        .library(
             name: "PilotType",
             targets: ["PilotType"]
         )
@@ -28,12 +32,16 @@ let package = Package(
             dependencies: ["PilotType"]
         ),
         .target(
+            name: "PilotTestSupport",
+            dependencies: []
+        ),
+        .target(
             name: "PilotType",
             dependencies: []
         ),
         .testTarget(
             name: "PilotTests",
-            dependencies: ["Pilot", "PilotType"]
+            dependencies: ["Pilot", "PilotTestSupport"]
         )
     ]
 )

--- a/Sources/PilotTestSupport/Mock.swift
+++ b/Sources/PilotTestSupport/Mock.swift
@@ -7,19 +7,19 @@
 
 import Foundation
 
-struct Mock {
+public struct Mock {
 
-    let statusCode: Int
-    let error: Error?
-    let data: Data?
+    public let statusCode: Int
+    public let error: Error?
+    public let data: Data?
 
-    init(statusCode: Int, error: Error?, data: Data?) {
+    public init(statusCode: Int, error: Error?, data: Data?) {
         self.statusCode = statusCode
         self.error = error
         self.data = data
     }
 
-    init(statusCode: Int, error: Error?, json: String?) {
+    public init(statusCode: Int, error: Error?, json: String?) {
         self.statusCode = statusCode
         self.error = error
         self.data = json.flatMap { $0.data(using: .utf8) }

--- a/Sources/PilotTestSupport/MockingURLProtocol.swift
+++ b/Sources/PilotTestSupport/MockingURLProtocol.swift
@@ -7,40 +7,40 @@
 
 import Foundation
 
-class MockingURLProtocol: URLProtocol {
+public final class MockingURLProtocol: URLProtocol {
 
-    enum Error: Swift.Error, LocalizedError, CustomDebugStringConvertible {
+    public enum Error: Swift.Error, LocalizedError, CustomDebugStringConvertible {
 
         case missingMock
 
-        var errorDescription: String? { debugDescription }
+        public var errorDescription: String? { debugDescription }
 
-        var debugDescription: String {
+        public var debugDescription: String {
             switch self {
             case .missingMock: return "Missing mock"
             }
         }
     }
 
-    static var mock: Mock?
+    public static var mock: Mock?
     private var dataTask: URLSessionDataTask?
 
-    static func urlSession() -> URLSession {
+    public static func urlSession() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockingURLProtocol.self]
         let urlSession = URLSession(configuration: configuration)
         return urlSession
     }
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    public override class func canInit(with request: URLRequest) -> Bool {
         return true
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    public override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
     }
 
-    override func startLoading() {
+    public override func startLoading() {
         guard let mock = Self.mock else {
             client?.urlProtocol(self, didFailWithError: Error.missingMock)
             return
@@ -62,7 +62,7 @@ class MockingURLProtocol: URLProtocol {
         client?.urlProtocolDidFinishLoading(self)
     }
 
-    override func stopLoading() {
+    public override func stopLoading() {
         dataTask?.cancel()
     }
 }
@@ -71,7 +71,7 @@ class MockingURLProtocol: URLProtocol {
 
 extension Mock {
 
-    var httpResponse: HTTPURLResponse? {
+    fileprivate var httpResponse: HTTPURLResponse? {
         .init(
             url: URL(string: "/")!,
             statusCode: statusCode,

--- a/Tests/PilotTests/PilotTests.swift
+++ b/Tests/PilotTests/PilotTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import PilotTestSupport
 import PilotType
 import XCTest
 @testable import Pilot


### PR DESCRIPTION
- Move off `MockingURLProtocol` and `Mock` to dedicated library